### PR TITLE
fix(Package): fixing broken peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
   "license": "MIT",
   "scripts": {},
   "dependencies": {
-    "eslint-plugin-chasevida": "~0.2.0",
+    "eslint-plugin-chasevida": "~0.1.2",
     "eslint-plugin-hapi": "~1.2.2"
   },
   "peerDependencies": {
-    "eslint-plugin-chasevida": "~0.2.0",
     "eslint-plugin-hapi": "~1.2.2"
   },
   "keywords": [


### PR DESCRIPTION
Had to adjust the version for `eslint-plugin-chasevida` from `0.2.0` to `0.1.2` to satisfy the following issue:

```
npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v4.2.2
npm ERR! npm  v2.14.7
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: eslint-plugin-chasevida@'>=0.2.0 <0.3.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.1.1","0.1.2"]
```

Then, for some reason, another issue relating to peerDependencies occured:

```
npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v4.2.2
npm ERR! npm  v2.14.7
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package eslint-plugin-chasevida@0.1.2 does not satisfy its siblings' peerDependencies requirements!
```

Moving `eslint-plugin-chasevida` from `peerDependencies` to `dependencies` fixes the above issue.
